### PR TITLE
Fix for catkin_make

### DIFF
--- a/chapter_8_codes/cv_bridge_tutorial_pkg/CMakeLists.txt
+++ b/chapter_8_codes/cv_bridge_tutorial_pkg/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   )
 
-
+find_package(OpenCV REQUIRED)
 catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
The catkin package is unable to build the file with the CMakeLists.txt that is shown in your repository for the package 'cv_bridge_tutorial_pkg'. The error is various undefined references. This was fixed by adding this line to the CMakeLists.txt : **find_package(OpenCV REQUIRED)**  or **find_package(OpenCV 3.0 REQUIRED)**